### PR TITLE
fix: add test for element with no text content

### DIFF
--- a/__tests__/getTextContent.test.js
+++ b/__tests__/getTextContent.test.js
@@ -9,8 +9,16 @@ test("Should get text content", () => {
       textContent: "text on parent",
     },
   };
+  const ELEM_WITH_NO_TEXT_CONTENT = {
+    parentElement: {
+      parentElement: {
+        noTextContent: null;
+      }
+    }
+  }
 
   expect(getTextContent(ELEM_WITH_TEXT_CONTENT)).toBe("text on itself");
+  expect(getTextContent(ELEM_WITH_NO_TEXT_CONTENT)).toBe("No textContent found, rename this");
   expect(getTextContent(ELEM_WITH_TEXT_CONTENT_ON_PARENT)).toBe(
     "text on parent"
   );


### PR DESCRIPTION
The proposed change adds a test for [getTextContent](https://github.com/save-hash-extension/save-hash/blob/2f598be418d691eae575e1de871a0a92363ca310/saveHash.dev.js#L249) expecting to return a *generic text content* when unable to find any on the DOM tree.

```diff
+ const ELEM_WITH_NO_TEXT_CONTENT = {
+   parentElement: {
+      parentElement: {
+        noTextContent: null;
+      }
+    }
+  }
   
+  expect(getTextContent(ELEM_WITH_NO_TEXT_CONTENT)).toBe("No textContent found, rename this");
```